### PR TITLE
Product CRUD Fix. 

### DIFF
--- a/app/migrations/Version20240522101959.php
+++ b/app/migrations/Version20240522101959.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240522101959 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update foreign keys to link product and category tables.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE product_2_categories DROP FOREIGN KEY FK_3C5C4B63BE6903FD');
+        $this->addSql('ALTER TABLE product_2_categories DROP FOREIGN KEY FK_3C5C4B634584665A');
+        $this->addSql('DROP INDEX IDX_3C5C4B63BE6903FD ON product_2_categories');
+        $this->addSql('DROP INDEX `primary` ON product_2_categories');
+        $this->addSql('ALTER TABLE product_2_categories CHANGE product_category_id category_id INT NOT NULL');
+        $this->addSql('ALTER TABLE product_2_categories ADD CONSTRAINT FK_3C5C4B6312469DE2 FOREIGN KEY (category_id) REFERENCES product_category (id) ON DELETE RESTRICT');
+        $this->addSql('ALTER TABLE product_2_categories ADD CONSTRAINT FK_3C5C4B634584665A FOREIGN KEY (product_id) REFERENCES product (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX IDX_3C5C4B6312469DE2 ON product_2_categories (category_id)');
+        $this->addSql('ALTER TABLE product_2_categories ADD PRIMARY KEY (product_id, category_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE product_2_categories DROP FOREIGN KEY FK_3C5C4B6312469DE2');
+        $this->addSql('ALTER TABLE product_2_categories DROP FOREIGN KEY FK_3C5C4B634584665A');
+        $this->addSql('DROP INDEX IDX_3C5C4B6312469DE2 ON product_2_categories');
+        $this->addSql('DROP INDEX `PRIMARY` ON product_2_categories');
+        $this->addSql('ALTER TABLE product_2_categories CHANGE category_id product_category_id INT NOT NULL');
+        $this->addSql('ALTER TABLE product_2_categories ADD CONSTRAINT FK_3C5C4B63BE6903FD FOREIGN KEY (product_category_id) REFERENCES product_category (id) ON UPDATE NO ACTION ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE product_2_categories ADD CONSTRAINT FK_3C5C4B634584665A FOREIGN KEY (product_id) REFERENCES product (id) ON UPDATE NO ACTION ON DELETE NO ACTION');
+        $this->addSql('CREATE INDEX IDX_3C5C4B63BE6903FD ON product_2_categories (product_category_id)');
+        $this->addSql('ALTER TABLE product_2_categories ADD PRIMARY KEY (product_id, product_category_id)');
+    }
+}

--- a/app/src/Entity/Product.php
+++ b/app/src/Entity/Product.php
@@ -34,9 +34,10 @@ class Product
     #[ORM\Column(nullable: true)]
     private ?int $discount = null;
 
-    #[ORM\ManyToMany(targetEntity: ProductCategory::class)]
+    #[ORM\ManyToMany(targetEntity: ProductCategory::class, inversedBy: 'products')]
     #[ORM\JoinTable(name: "product_2_categories")]
-    #[ORM\JoinColumn(referencedColumnName: "id", nullable: false)]
+    #[ORM\JoinColumn(name: "product_id", referencedColumnName: "id", onDelete: "CASCADE")]
+    #[ORM\InverseJoinColumn(name: "category_id", referencedColumnName: "id", onDelete: "RESTRICT")]
     private Collection $categories;
 
     public function __construct()

--- a/app/templates/product/edit.html.twig
+++ b/app/templates/product/edit.html.twig
@@ -38,11 +38,13 @@
     </div>
     <div class="mb-3">
         <button class="btn btn-outline-success">{{ button_label|default('Save') }}</button>
+        <a class="btn btn-outline-danger" href="{{ path('product_index') }}">Back to list</a>
+    </div>
+    {{ form_end(form) }}
+    <div class="mb-3">
         <form method="post" action="{{ path('product_delete', {'id': product.id}) }}" style="display: inline-block">
             <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ product.id) }}">
             <button class="btn btn-outline-warning" type="submit">Delete</button>
         </form>
-        <a class="btn btn-outline-danger" href="{{ path('product_index') }}">Back to list</a>
     </div>
-    {{ form_end(form) }}
 {% endblock %}


### PR DESCRIPTION
Fixed:

- Product editing does not work: error 422 "The CSRF token is invalid. Please try to resubmit the form."
- Deleting a product on the edit page: : error 422 "The CSRF token is invalid. Please try to resubmit the form."
- Removing a product from the product list does not work:
```
An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails.
```